### PR TITLE
graphql

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,76 +1,76 @@
 ## Assignment: Graphql
 ### Tasks:
-1. Add logic to the restful endpoints (users, posts, profiles, member-types folders in ./src/routes).  
-   1.1. npm run test - 100%  
-2. Add logic to the graphql endpoint (graphql folder in ./src/routes).  
-Constraints and logic for gql queries should be done based on restful implementation.  
-For each subtask provide an example of POST body in the PR.  
-All dynamic values should be sent via "variables" field.  
-If the properties of the entity are not specified, then return the id of it.  
-`userSubscribedTo` - these are users that the current user is following.  
-`subscribedToUser` - these are users who are following the current user.  
-   
-   * Get gql requests:  
-   2.1. Get users, profiles, posts, memberTypes - 4 operations in one query.  
-   2.2. Get user, profile, post, memberType by id - 4 operations in one query.  
-   2.3. Get users with their posts, profiles, memberTypes.  
-   2.4. Get user by id with his posts, profile, memberType.  
-   2.5. Get users with their `userSubscribedTo`, profile.  
-   2.6. Get user by id with his `subscribedToUser`, posts.  
-   2.7. Get users with their `userSubscribedTo`, `subscribedToUser` (additionally for each user in `userSubscribedTo`, `subscribedToUser` add their `userSubscribedTo`, `subscribedToUser`).  
-   * Create gql requests:   
-   2.8. Create user.  
-   2.9. Create profile.  
-   2.10. Create post.  
-   2.11. [InputObjectType](https://graphql.org/graphql-js/type/#graphqlinputobjecttype) for DTOs.  
-   * Update gql requests:  
-   2.12. Update user.  
-   2.13. Update profile.  
-   2.14. Update post.  
-   2.15. Update memberType.  
-   2.16. Subscribe to; unsubscribe from.  
-   2.17. [InputObjectType](https://graphql.org/graphql-js/type/#graphqlinputobjecttype) for DTOs.  
+1. Add logic to the restful endpoints (users, posts, profiles, member-types folders in ./src/routes).
+   1.1. npm run test - 100%
+2. Add logic to the graphql endpoint (graphql folder in ./src/routes).
+Constraints and logic for gql queries should be done based on restful implementation.
+For each subtask provide an example of POST body in the PR.
+All dynamic values should be sent via "variables" field.
+If the properties of the entity are not specified, then return the id of it.
+`userSubscribedTo` - these are users that the current user is following.
+`subscribedToUser` - these are users who are following the current user.
 
-3. Solve `n+1` graphql problem with [dataloader](https://www.npmjs.com/package/dataloader) package in all places where it should be used.  
-   You can use only one "findMany" call per loader to consider this task completed.  
-   It's ok to leave the use of the dataloader even if only one entity was requested. But additionally (no extra score) you can optimize the behavior for such cases => +1 db call is allowed per loader.  
-   3.1. List where the dataloader was used with links to the lines of code (creation in gql context and call in resolver).  
-4. Limit the complexity of the graphql queries by their depth with [graphql-depth-limit](https://www.npmjs.com/package/graphql-depth-limit) package.   
-   4.1. Provide a link to the line of code where it was used.  
-   4.2. Specify a POST body of gql query that ends with an error due to the operation of the rule. Request result should be with `errors` field (and with or without `data:null`) describing the error.  
+   * Get gql requests:
+   2.1. Get users, profiles, posts, memberTypes - 4 operations in one query.
+   2.2. Get user, profile, post, memberType by id - 4 operations in one query.
+   2.3. Get users with their posts, profiles, memberTypes.
+   2.4. Get user by id with his posts, profile, memberType.
+   2.5. Get users with their `userSubscribedTo`, profile.
+   2.6. Get user by id with his `subscribedToUser`, posts.
+   2.7. Get users with their `userSubscribedTo`, `subscribedToUser` (additionally for each user in `userSubscribedTo`, `subscribedToUser` add their `userSubscribedTo`, `subscribedToUser`).
+   * Create gql requests:
+   2.8. Create user.
+   2.9. Create profile.
+   2.10. Create post.
+   2.11. [InputObjectType](https://graphql.org/graphql-js/type/#graphqlinputobjecttype) for DTOs.
+   * Update gql requests:
+   2.12. Update user.
+   2.13. Update profile.
+   2.14. Update post.
+   2.15. Update memberType.
+   2.16. Subscribe to; unsubscribe from.
+   2.17. [InputObjectType](https://graphql.org/graphql-js/type/#graphqlinputobjecttype) for DTOs.
 
-### Description:  
-All dependencies to complete this task are already installed.  
-You are free to install new dependencies as long as you use them.  
-App template was made with fastify, but you don't need to know much about fastify to get the tasks done.  
-All templates for restful endpoints are placed, just fill in the logic for each of them.  
-Use the "db" property of the "fastify" object as a database access methods ("db" is an instance of the DB class => ./src/utils/DB/DB.ts).  
-Body, params have fixed structure for each restful endpoint due to jsonSchema (schema.ts files near index.ts).  
+3. Solve `n+1` graphql problem with [dataloader](https://www.npmjs.com/package/dataloader) package in all places where it should be used.
+   You can use only one "findMany" call per loader to consider this task completed.
+   It's ok to leave the use of the dataloader even if only one entity was requested. But additionally (no extra score) you can optimize the behavior for such cases => +1 db call is allowed per loader.
+   3.1. List where the dataloader was used with links to the lines of code (creation in gql context and call in resolver).
+4. Limit the complexity of the graphql queries by their depth with [graphql-depth-limit](https://www.npmjs.com/package/graphql-depth-limit) package.
+   4.1. Provide a link to the line of code where it was used.
+   4.2. Specify a POST body of gql query that ends with an error due to the operation of the rule. Request result should be with `errors` field (and with or without `data:null`) describing the error.
+
+### Description:
+All dependencies to complete this task are already installed.
+You are free to install new dependencies as long as you use them.
+App template was made with fastify, but you don't need to know much about fastify to get the tasks done.
+All templates for restful endpoints are placed, just fill in the logic for each of them.
+Use the "db" property of the "fastify" object as a database access methods ("db" is an instance of the DB class => ./src/utils/DB/DB.ts).
+Body, params have fixed structure for each restful endpoint due to jsonSchema (schema.ts files near index.ts).
 
 ### Description for the 1 task:
-If the requested entity is missing - send 404 http code.  
-If operation cannot be performed because of the client input - send 400 http code.  
-You can use methods of "reply" to set http code or throw an [http error](https://github.com/fastify/fastify-sensible#fastifyhttperrors).  
-If operation is successfully completed, then return an entity or array of entities from http handler (fastify will stringify object/array and will send it).  
+If the requested entity is missing - send 404 http code.
+If operation cannot be performed because of the client input - send 400 http code.
+You can use methods of "reply" to set http code or throw an [http error](https://github.com/fastify/fastify-sensible#fastifyhttperrors).
+If operation is successfully completed, then return an entity or array of entities from http handler (fastify will stringify object/array and will send it).
 
-Relation fields are only stored in dependent/child entities. E.g. profile stores "userId" field.  
-You are also responsible for verifying that the relations are real. E.g. "userId" belongs to the real user.  
-So when you delete dependent entity, you automatically delete relations with its parents.  
-But when you delete parent entity, you need to delete relations from child entities yourself to keep the data relevant.   
-(In the next rss-school task, you will use a full-fledged database that also can automatically remove child entities when the parent is deleted, verify keys ownership and instead of arrays for storing keys, you will use additional "join" tables)  
+Relation fields are only stored in dependent/child entities. E.g. profile stores "userId" field.
+You are also responsible for verifying that the relations are real. E.g. "userId" belongs to the real user.
+So when you delete dependent entity, you automatically delete relations with its parents.
+But when you delete parent entity, you need to delete relations from child entities yourself to keep the data relevant.
+(In the next rss-school task, you will use a full-fledged database that also can automatically remove child entities when the parent is deleted, verify keys ownership and instead of arrays for storing keys, you will use additional "join" tables)
 
-To determine that all your restful logic works correctly => run the script "npm run test".  
-But be careful because these tests are integration (E.g. to test "delete" logic => it creates the entity via a "create" endpoint).  
+To determine that all your restful logic works correctly => run the script "npm run test".
+But be careful because these tests are integration (E.g. to test "delete" logic => it creates the entity via a "create" endpoint).
 
-### Description for the 2 task:  
-You are free to create your own gql environment as long as you use predefined graphql endpoint (./src/routes/graphql/index.ts).  
-(or stick to the [default code-first](https://github.dev/graphql/graphql-js/blob/ffa18e9de0ae630d7e5f264f72c94d497c70016b/src/__tests__/starWarsSchema.ts))  
+### Description for the 2 task:
+You are free to create your own gql environment as long as you use predefined graphql endpoint (./src/routes/graphql/index.ts).
+(or stick to the [default code-first](https://github.dev/graphql/graphql-js/blob/ffa18e9de0ae630d7e5f264f72c94d497c70016b/src/__tests__/starWarsSchema.ts))
 
 ### Description for the 3 task:
-If you have chosen a non-default gql environment, then the connection of some functionality may differ, be sure to report this in the PR.  
+If you have chosen a non-default gql environment, then the connection of some functionality may differ, be sure to report this in the PR.
 
-### Description for the 4 task:  
-If you have chosen a non-default gql environment, then the connection of some functionality may differ, be sure to report this in the PR.  
-Limit the complexity of the graphql queries by their depth with "graphql-depth-limit" package.  
-E.g. User can refer to other users via properties `userSubscribedTo`, `subscribedToUser` and users within them can also have `userSubscribedTo`, `subscribedToUser` and so on.  
+### Description for the 4 task:
+If you have chosen a non-default gql environment, then the connection of some functionality may differ, be sure to report this in the PR.
+Limit the complexity of the graphql queries by their depth with "graphql-depth-limit" package.
+E.g. User can refer to other users via properties `userSubscribedTo`, `subscribedToUser` and users within them can also have `userSubscribedTo`, `subscribedToUser` and so on.
 Your task is to add a new rule (created by "graphql-depth-limit") in [validation](https://graphql.org/graphql-js/validation/) to limit such nesting to (for example) 6 levels max.

--- a/src/routes/graphql/index.ts
+++ b/src/routes/graphql/index.ts
@@ -1,5 +1,14 @@
+import {
+  GraphQLList,
+  GraphQLObjectType,
+  GraphQLSchema,
+  graphql,
+  GraphQLID,
+} from 'graphql';
 import { FastifyPluginAsyncJsonSchemaToTs } from '@fastify/type-provider-json-schema-to-ts';
 import { graphqlBodySchema } from './schema';
+import { User, Post, MemberType, Profile } from './types';
+
 
 const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
   fastify
@@ -11,7 +20,108 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         body: graphqlBodySchema,
       },
     },
-    async function (request, reply) {}
+    async function (request, reply) {
+      const schema = new GraphQLSchema({
+        query: new GraphQLObjectType({
+          name: 'BasicQuery',
+          fields: {
+            users: {
+              type: new GraphQLList(User),
+              async resolve() {
+                return await fastify.db.users.findMany();
+              }
+            },
+            posts: {
+              type: new GraphQLList(Post),
+              async resolve() {
+                return await fastify.db.posts.findMany();
+              }
+            },
+            memberTypes: {
+              type: new GraphQLList(MemberType),
+              async resolve() {
+                return await fastify.db.memberTypes.findMany();
+              }
+            },
+            profiles: {
+              type: new GraphQLList(Profile),
+              async resolve() {
+                return await fastify.db.profiles.findMany();
+              }
+            },
+            user: {
+              type: User,
+              args: {
+                id: { type: GraphQLID }
+              },
+              async resolve(_, { id }) {
+                const user = await fastify.db.users.findOne({ key: 'id', equals: id });
+
+                if (user === null) {
+                  throw fastify.httpErrors.notFound('User does not exsist');
+                }
+
+                return user;
+              }
+            },
+            post: {
+              type: Post,
+              args: {
+                id: { type: GraphQLID }
+              },
+              async resolve(_, { id }) {
+                const post = await fastify.db.posts.findOne({ key: 'id', equals: id });
+
+                if (post === null) {
+                  throw fastify.httpErrors.notFound('Post does not exsist');
+                }
+
+                return post;
+              }
+            },
+            profile: {
+              type: Profile,
+              args: {
+                id: { type: GraphQLID }
+              },
+              async resolve(_, { id }) {
+                const profile = await fastify.db.profiles.findOne({ key: 'id', equals: id });
+
+                if (profile === null) {
+                  throw fastify.httpErrors.notFound('Post does not exsist');
+                }
+
+                return profile;
+              }
+            },
+            memberType: {
+              type: MemberType,
+              args: {
+                id: { type: GraphQLID }
+              },
+              async resolve(_, { id }) {
+                const memberType = await fastify.db.memberTypes.findOne({ key: 'id', equals: id });
+
+                if (memberType === null) {
+                  throw fastify.httpErrors.notFound('Post does not exsist');
+                }
+
+                return memberType;
+              }
+            },
+          }
+        }),
+      });
+
+      const result = await graphql({
+        schema,
+        source: request.body.query as any,
+        variableValues: request.body.variables,
+        contextValue: fastify,
+      });
+
+      return result;
+    }
   );
 };
 

--- a/src/routes/graphql/types.ts
+++ b/src/routes/graphql/types.ts
@@ -1,0 +1,93 @@
+import {
+  GraphQLList,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLInt,
+  GraphQLID,
+  GraphQLOutputType,
+} from 'graphql';
+
+const User: GraphQLOutputType = new GraphQLObjectType({
+  name: 'User',
+  fields: () => ({
+    id: { type: GraphQLID },
+    firstName: { type: GraphQLString },
+    lastName: { type: GraphQLString },
+    email: { type: GraphQLString },
+    subscribedToUserIds: { type: new GraphQLList(GraphQLString) },
+    userSubscribedTo: {
+      type: new GraphQLList(User),
+      async resolve(user, _, fastify ) {
+        return await fastify.db.users.findMany({key: 'subscribedToUserIds', inArray: user.id});
+      }
+    },
+    subscribedToUser: {
+      type: new GraphQLList(User),
+      async resolve(user, _, fastify ) {
+        return user.subscribedToUserIds.map(async (id: string) => {
+          return await fastify.db.users.findOne({key: 'id', equals: id});
+        });
+      }
+    },
+    posts: {
+      type: new GraphQLList(Post),
+      async resolve(user, _, fastify) {
+        return await fastify.db.posts.findMany({ key: 'userId', equals: user.id });
+      }
+    },
+    profile: {
+      type: Profile,
+      async resolve(user, _, fastify) {
+        return await fastify.db.profiles.findOne({ key: 'userId', equals: user.id });
+      }
+    },
+    memberType: {
+      type: MemberType,
+      async resolve(user, _, fastify) {
+        const profile = await fastify.db.profiles.findOne({ key: 'userId', equals: user.id });
+
+        if (user.profile === null) {
+          return null;
+        }
+
+        return await fastify.db.memberTypes.findOne({ key: 'id', equals: profile.memberTypeId });
+      }
+    }
+  }),
+});
+
+const Post = new GraphQLObjectType({
+  name: 'Post',
+  fields: () => ({
+    id: { type: GraphQLID },
+    title: { type: GraphQLString },
+    content: { type: GraphQLString },
+    userId: { type: GraphQLString },
+  }),
+});
+
+const MemberType = new GraphQLObjectType({
+  name: 'MemberType',
+  fields: () => ({
+    id: { type: GraphQLID },
+    discount: { type: GraphQLInt },
+    monthPostsLimit: { type: GraphQLInt },
+  }),
+});
+
+const Profile = new GraphQLObjectType({
+  name: 'Profile',
+  fields: () => ({
+    id: { type: GraphQLID },
+    avatar: { type: GraphQLString },
+    sex: { type: GraphQLString },
+    birthday: { type: GraphQLInt },
+    country: { type: GraphQLString },
+    street: { type: GraphQLString },
+    city: { type: GraphQLString },
+    memberTypeId: { type: GraphQLString },
+    userId: { type: GraphQLString },
+  }),
+});
+
+export { User, Post, MemberType, Profile };

--- a/src/routes/member-types/index.ts
+++ b/src/routes/member-types/index.ts
@@ -8,7 +8,10 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
 ): Promise<void> => {
   fastify.get('/', async function (request, reply): Promise<
     MemberTypeEntity[]
-  > {});
+  > {
+    return await fastify.db.memberTypes.findMany();
+
+  });
 
   fastify.get(
     '/:id',
@@ -17,7 +20,15 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<MemberTypeEntity> {}
+    async function (request, reply): Promise<MemberTypeEntity> {
+      const member = await fastify.db.memberTypes.findOne({ key: 'id', equals: request.params.id });
+
+      if (member === null) {
+        throw fastify.httpErrors.notFound('Member  not exsist');
+      }
+
+      return member;
+    }
   );
 
   fastify.patch(
@@ -28,7 +39,19 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<MemberTypeEntity> {}
+    async function (request, reply): Promise<MemberTypeEntity> {
+      const member = await fastify.db.memberTypes.findOne({ key: 'id', equals: request.params.id });
+
+      if (member === null) {
+        throw fastify.httpErrors.badRequest('Member not exsist');
+      }
+
+      const updatedMember = await fastify.db.memberTypes.change(request.params.id, {
+        ...request.body,
+      });
+
+      return updatedMember;
+    }
   );
 };
 

--- a/src/routes/profiles/index.ts
+++ b/src/routes/profiles/index.ts
@@ -8,7 +8,7 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
 ): Promise<void> => {
   fastify.get('/', async function (request, reply): Promise<
     ProfileEntity[]
-  > {});
+  > { return await fastify.db.profiles.findMany();});
 
   fastify.get(
     '/:id',
@@ -17,7 +17,15 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<ProfileEntity> {}
+    async function (request, reply): Promise<ProfileEntity> {
+      const profile = await fastify.db.profiles.findOne({ key: 'id', equals: request.params.id });
+
+      if (profile === null) {
+        throw fastify.httpErrors.notFound('Profile does not exsist');
+      }
+
+      return profile;
+    }
   );
 
   fastify.post(
@@ -27,7 +35,27 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         body: createProfileBodySchema,
       },
     },
-    async function (request, reply): Promise<ProfileEntity> {}
+    async function (request, reply): Promise<ProfileEntity> {
+      const memberType = await fastify.db.memberTypes.findOne({ key: 'id', equals: request.body.memberTypeId });
+
+      if (memberType === null) {
+        throw fastify.httpErrors.badRequest('fun');
+      }
+
+      const user = await fastify.db.profiles.findOne({ key: 'userId', equals: request.body.userId });
+
+      if (user) {
+        throw fastify.httpErrors.badRequest('fun');
+      }
+
+      const newProfile = await fastify.db.profiles.create(request.body);
+
+      if (!newProfile) {
+        throw fastify.httpErrors.badRequest('fun');
+      }
+
+      return newProfile;
+    }
   );
 
   fastify.delete(
@@ -37,7 +65,17 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<ProfileEntity> {}
+    async function (request, reply): Promise<ProfileEntity> {
+      const profile = await fastify.db.profiles.findOne({ key: 'id', equals: request.params.id });
+
+      if (profile === null) {
+        throw fastify.httpErrors.badRequest('fun');
+      }
+
+      const profileToDelete = await fastify.db.profiles.delete(request.params.id);
+
+      return profileToDelete;
+    }
   );
 
   fastify.patch(
@@ -48,7 +86,19 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<ProfileEntity> {}
+    async function (request, reply): Promise<ProfileEntity> {
+      const profile = await fastify.db.profiles.findOne({ key: 'id', equals: request.params.id });
+
+      if (profile === null) {
+        throw fastify.httpErrors.badRequest('fun');
+      }
+
+      const updatedProfile= await fastify.db.profiles.change(request.params.id, {
+        ...request.body,
+      });
+
+      return updatedProfile;
+    }
   );
 };
 

--- a/src/routes/users/index.ts
+++ b/src/routes/users/index.ts
@@ -102,7 +102,25 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<UserEntity> {}
+    async function (request, reply): Promise<UserEntity> {
+      const user = await fastify.db.users.findOne({ key: 'id', equals: request.body.userId });
+
+      if (user === null) {
+        throw fastify.httpErrors.notFound('User does not exsist');
+      }
+
+      const updatedUserId = await fastify.db.users.change(
+        request.body.userId,
+        {
+          subscribedToUserIds: [
+            ...user.subscribedToUserIds,
+            request.params.id,
+          ],
+        }
+      );
+
+      return updatedUserId;
+    }
   );
 
   fastify.post(

--- a/src/routes/users/index.ts
+++ b/src/routes/users/index.ts
@@ -10,7 +10,10 @@ import type { UserEntity } from '../../utils/DB/entities/DBUsers';
 const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
   fastify
 ): Promise<void> => {
-  fastify.get('/', async function (request, reply): Promise<UserEntity[]> {});
+  fastify.get('/', async function (request, reply): Promise<UserEntity[]> {
+    const Users = await fastify.db.users.findMany();
+    return Users;
+  });
 
   fastify.get(
     '/:id',

--- a/src/routes/users/index.ts
+++ b/src/routes/users/index.ts
@@ -163,7 +163,19 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<UserEntity> {}
+    async function (request, reply): Promise<UserEntity> {
+       const user = await fastify.db.users.findOne({ key: 'id', equals: request.params.id });
+
+      if (user === null) {
+        throw fastify.httpErrors.badRequest('User does not exsist');
+      }
+
+      const updatedUserOne = await fastify.db.users.change(request.params.id, {
+        ...request.body,
+      });
+
+      return updatedUserOne;
+    }
   );
 };
 

--- a/src/routes/users/index.ts
+++ b/src/routes/users/index.ts
@@ -22,7 +22,16 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<UserEntity> {}
+    async function (request, reply): Promise<UserEntity> {
+      const userById = await fastify.db.users.findOne({key: 'id', equals: request.params.id});
+
+      if (userById === null) {
+
+        throw fastify.httpErrors.notFound("User does not found");
+      }
+
+      return userById;
+    }
   );
 
   fastify.post(


### PR DESCRIPTION
Tasks:
Add logic to the restful endpoints (users, posts, profiles, member-types folders in ./src/routes).
1.1. npm run test - 100%

Add logic to the graphql endpoint (graphql folder in ./src/routes).
Constraints and logic for gql queries should be done based on restful implementation.
For each subtask provide an example of POST body in the PR.
All dynamic values should be sent via "variables" field.
If the properties of the entity are not specified, then return the id of it.
userSubscribedTo - these are users that the current user is following.
subscribedToUser - these are users who are following the current user.

Get gql requests:
2.1. Get users, profiles, posts, memberTypes - 4 operations in one query.
2.2. Get user, profile, post, memberType by id - 4 operations in one query.
2.3. Get users with their posts, profiles, memberTypes.
2.4. Get user by id with his posts, profile, memberType.
2.5. Get users with their userSubscribedTo, profile.
2.6. Get user by id with his subscribedToUser, posts.
2.7. Get users with their userSubscribedTo, subscribedToUser (additionally for each user in userSubscribedTo, subscribedToUser add their userSubscribedTo, subscribedToUser).
Create gql requests:
2.8. Create user.
2.9. Create profile.
2.10. Create post.
2.11. [InputObjectType](https://graphql.org/graphql-js/type/#graphqlinputobjecttype) for DTOs.
Update gql requests:
2.12. Update user.
2.13. Update profile.
2.14. Update post.
2.15. Update memberType.
2.16. Subscribe to; unsubscribe from.
2.17. [InputObjectType](https://graphql.org/graphql-js/type/#graphqlinputobjecttype) for DTOs.
Solve n+1 graphql problem with [dataloader](https://www.npmjs.com/package/dataloader) package in all places where it should be used.
You can use only one "findMany" call per loader to consider this task completed.
It's ok to leave the use of the dataloader even if only one entity was requested. But additionally (no extra score) you can optimize the behavior for such cases => +1 db call is allowed per loader.
3.1. List where the dataloader was used with links to the lines of code (creation in gql context and call in resolver).

Limit the complexity of the graphql queries by their depth with [graphql-depth-limit](https://www.npmjs.com/package/graphql-depth-limit) package.
4.1. Provide a link to the line of code where it was used.
4.2. Specify a POST body of gql query that ends with an error due to the operation of the rule. Request result should be with errors field (and with or without data:null) describing the error.

Description:
All dependencies to complete this task are already installed.
You are free to install new dependencies as long as you use them.
App template was made with fastify, but you don't need to know much about fastify to get the tasks done.
All templates for restful endpoints are placed, just fill in the logic for each of them.
Use the "db" property of the "fastify" object as a database access methods ("db" is an instance of the DB class => ./src/utils/DB/DB.ts).
Body, params have fixed structure for each restful endpoint due to jsonSchema (schema.ts files near index.ts).

Description for the 1 task:
If the requested entity is missing - send 404 http code.
If operation cannot be performed because of the client input - send 400 http code.
You can use methods of "reply" to set http code or throw an [http error](https://github.com/fastify/fastify-sensible#fastifyhttperrors).
If operation is successfully completed, then return an entity or array of entities from http handler (fastify will stringify object/array and will send it).

Relation fields are only stored in dependent/child entities. E.g. profile stores "userId" field.
You are also responsible for verifying that the relations are real. E.g. "userId" belongs to the real user.
So when you delete dependent entity, you automatically delete relations with its parents.
But when you delete parent entity, you need to delete relations from child entities yourself to keep the data relevant.
(In the next rss-school task, you will use a full-fledged database that also can automatically remove child entities when the parent is deleted, verify keys ownership and instead of arrays for storing keys, you will use additional "join" tables)

To determine that all your restful logic works correctly => run the script "npm run test".
But be careful because these tests are integration (E.g. to test "delete" logic => it creates the entity via a "create" endpoint).

Description for the 2 task:
You are free to create your own gql environment as long as you use predefined graphql endpoint (./src/routes/graphql/index.ts).
(or stick to the [default code-first](https://github.dev/graphql/graphql-js/blob/ffa18e9de0ae630d7e5f264f72c94d497c70016b/src/__tests__/starWarsSchema.ts))

Description for the 3 task:
If you have chosen a non-default gql environment, then the connection of some functionality may differ, be sure to report this in the PR.

Description for the 4 task:
If you have chosen a non-default gql environment, then the connection of some functionality may differ, be sure to report this in the PR.
Limit the complexity of the graphql queries by their depth with "graphql-depth-limit" package.
E.g. User can refer to other users via properties userSubscribedTo, subscribedToUser and users within them can also have userSubscribedTo, subscribedToUser and so on.
Your task is to add a new rule (created by "graphql-depth-limit") in [validation](https://graphql.org/graphql-js/validation/) to limit such nesting to (for example) 6 levels max.